### PR TITLE
Fix color reset writer errors and behavior

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -591,7 +591,20 @@ func (w *colorResetWriter) Write(p []byte) (int, error) {
 func (w *colorResetWriter) Flush() error {
 	// Reset colors at the end of output
 	_, err := w.dest.Write([]byte(colorReset))
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to write color reset sequence: %w", err)
+	}
+	return nil
+}
+
+// Close ensures colors are reset when the writer is closed
+func (w *colorResetWriter) Close() error {
+	// Reset colors when closing the writer
+	_, err := w.dest.Write([]byte(colorReset))
+	if err != nil {
+		return fmt.Errorf("failed to write color reset sequence on close: %w", err)
+	}
+	return nil
 }
 
 func newTaskLogWriter(cli *CLI, taskKey, stream string, showPrefix bool) io.Writer {


### PR DESCRIPTION
Improve `colorResetWriter` error handling and add a `Close` method to prevent silent error discarding and ensure proper terminal color reset.

---
<a href="https://cursor.com/background-agent?bcId=bc-27e7850b-01ca-48cf-aa20-8ddba652fd5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-27e7850b-01ca-48cf-aa20-8ddba652fd5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

